### PR TITLE
0.9.1: https > http fix for 'Connect timed out'

### DIFF
--- a/Plugin.pm
+++ b/Plugin.pm
@@ -79,7 +79,7 @@ sub initPlugin {
 
     # Initialize the plugin with the given values. The 'feed' is the first
     # method called. The available menu entries will be shown in the new 
-    # menu entry 'soundclound'. 
+    # menu entry 'soundcloud'. 
     $class->SUPER::initPlugin(
         feed   => \&toplevel,
         tag    => 'squeezecloud',

--- a/Plugin.pm
+++ b/Plugin.pm
@@ -340,7 +340,7 @@ sub tracksHandler {
 		$log->debug("max: " . $max);
         $quantity = $max;
 
-		my $method = "https";
+		my $method = "http";
 		my $uid = $passDict->{'uid'} || '';
 
         # If this is set to one then the user has provided the API key. This 
@@ -418,7 +418,7 @@ sub tracksHandler {
         # top level menu items would not be visible and the search type value 
         # would not have been passed into this method here.
 		if ($authenticated && $prefs->get('apiKey')) {
-			$method = "https";
+			$method = "http";
 			$params .= "&oauth_token=" . $prefs->get('apiKey');
 		} else {
 			$params .= "&client_id=$CLIENT_ID";

--- a/install.xml
+++ b/install.xml
@@ -3,7 +3,7 @@
 <extension>
 	<name>PLUGIN_SQUEEZECLOUD</name>
 	<module>Plugins::SqueezeCloud::Plugin</module>
-	<version>0.9.0</version>
+	<version>0.9.1</version>
 	<description>PLUGIN_SQUEEZECLOUD_DESC</description>
 	<icon>plugins/SqueezeCloud/icon.png</icon>
 	<defaultState>enabled</defaultState>


### PR DESCRIPTION
A fix for #13
 - switching to _http_ API call.
 - updating to 0.9.1 (pull request for _gh-page_ update here #16)

 > Verified on Linux, Logitech Media Server Version: 7.9.0 - 1487582706