### PR TITLE
Call back to a secure page when requesting an API key.

### DIFF
--- a/HTML/EN/plugins/SqueezeCloud/settings/basic.html
+++ b/HTML/EN/plugins/SqueezeCloud/settings/basic.html
@@ -4,7 +4,7 @@
 	<div class="prefDesc">
 		<input type="text" class="stdedit" name="pref_apiKey" value="[% prefs.apiKey %]" size="40" />
 		<br/>
-		<a target="_blank" href="https://soundcloud.com/connect?client_id=112d35211af80d72c8ff470ab66400d8&redirect_uri=http%3A%2F%2Fdanielvijge.github.io%2FSqueezeCloud%2Fcallback.html&response_type=code_and_token&scope=non-expiring&display=popup">Get your apiKey for squeezecloud at soundcloud.com</a>
+		<a target="_blank" href="https://soundcloud.com/connect?client_id=112d35211af80d72c8ff470ab66400d8&redirect_uri=https%3A%2F%2Fdanielvijge.github.io%2FSqueezeCloud%2Fcallback.html&response_type=code_and_token&scope=non-expiring&display=popup">Get your apiKey for squeezecloud at soundcloud.com</a>
 	</div>
 
 	[% END %]


### PR DESCRIPTION
For this to work, SoundCloud will need to know about the updated redirect_uri.  I expect that this can be done at https://soundcloud.com/you/apps, but I can’t check because SoundCloud aren’t currently accepting new developer signups.