### PR TITLE
Handle SoundCloud URLs passed to “Tune In URL”

### DIFF
--- a/Plugin.pm
+++ b/Plugin.pm
@@ -39,6 +39,9 @@ use constant API_DEFAULT_ITEMS_COUNT => 30;
 # than 8000 + 200 items can exist in a menu list.
 use constant API_MAX_ITEMS => 500;
 
+# Which URLs should we catch when pasted into the "Tune In URL" field?
+use constant PAGE_URL_REGEXP => qr{^https?://soundcloud\.com/};
+
 my $log;
 my $compat;
 my $CLIENT_ID = "112d35211af80d72c8ff470ab66400d8";
@@ -102,6 +105,10 @@ sub initPlugin {
     Slim::Player::ProtocolHandlers->registerHandler(
         soundcloud => 'Plugins::SqueezeCloud::ProtocolHandler'
     );
+
+	Slim::Player::ProtocolHandlers->registerURLHandler(
+	    PAGE_URL_REGEXP() => 'Plugins::SqueezeCloud::ProtocolHandler'
+	) if Slim::Player::ProtocolHandlers->can('registerURLHandler');
 }
 
 # Called when the plugin is stopped

--- a/ProtocolHandler.pm
+++ b/ProtocolHandler.pm
@@ -320,4 +320,19 @@ sub handleDirectError {
 	$client->controller()->playerStreamingFailed( $client, 'PLUGIN_SQUEEZECLOUD_STREAM_FAILED' );
 }
 
+sub explodePlaylist {
+	my ( $class, $client, $uri, $callback ) = @_;
+
+	if ( $uri =~ Plugins::SqueezeCloud::Plugin::PAGE_URL_REGEXP ) {
+		Plugins::SqueezeCloud::Plugin::urlHandler(
+			$client,
+			sub { $callback->([map {$_->{'play'}} @{$_[0]->{'items'}}]) },
+			{'search' => $uri},
+		);
+	}
+	else {
+		$callback->([]);
+	}
+}
+
 1;


### PR DESCRIPTION
A number of plugins allow you to give them a webpage URL, and they’ll play the music associated with that webpage, e.g., the Band’s Campout plugin has a “Bandcamp URL” field, the YouTube plugin has a “YouTube URL or Video id” field, etc. However, it would be more convenient if you could paste the URL into the “Tune In URL” field and have LMS work out for you which plugin to use.

This commit provides that for SoundCloud tracks.

Support for this in LMS landed on the public/8.0 branch today, but this change should safely do nothing on older versions.