### PR TITLE
More HTTPS

### DIFF
--- a/Plugin.pm
+++ b/Plugin.pm
@@ -339,7 +339,7 @@ sub tracksHandler {
 		$log->debug("i: " . $i);
 
 		# Limit the amount of items to fetch because the API allows only a max 
-        # of 200 per response. See http://developers.soundcloud.com/docs#pagination
+        # of 200 per response. See https://developers.soundcloud.com/docs#pagination
 		my $max = min($quantity - scalar @$menu, API_MAX_ITEMS_PER_CALL);
 		$log->debug("max: " . $max);
         $quantity = $max;
@@ -470,7 +470,7 @@ sub tracksHandler {
                     $parser->($json, $menu);
                 }
 	
-				# max offset = 8000, max index = 200 sez soundcloud http://developers.soundcloud.com/docs#pagination
+				# max offset = 8000, max index = 200 sez soundcloud https://developers.soundcloud.com/docs#pagination
 				my $total = API_MAX_ITEMS + $quantity;
 				if (exists $passDict->{'total'}) {
 					$total = $passDict->{'total'}

--- a/README.md
+++ b/README.md
@@ -8,15 +8,15 @@ Press the _Apply_ button and restart LMS.
 After installation, configure it via _Settings_ > _Advanced_ > _SqueezeCloud_
 
 The plugin is included as a default third party resource. It is distributed via my
-[personal repository](http://server.vijge.net/squeezebox/) This third party repository
+[personal repository](https://server.vijge.net/squeezebox/) This third party repository
 is synced with the repository XML files on GitHub. It is also possible to directly include
 the repository XML from GitHub. For the release version, include
     
-    http://danielvijge.github.io/SqueezeCloud/public.xml
+    https://danielvijge.github.io/SqueezeCloud/public.xml
 
 For the development version (updated with every commit), include
 
-    http://danielvijge.github.io/SqueezeCloud/public-dev.xml
+    https://danielvijge.github.io/SqueezeCloud/public-dev.xml
 
 ## SSL support ##
 

--- a/public.template.xml
+++ b/public.template.xml
@@ -6,7 +6,7 @@
     <plugin name="SqueezeCloud" version="{{ env['VERSION'] }}" minTarget="7.5" maxTarget="*">
       <title lang="EN">SqueezeCloud</title>
       <desc lang="EN">Browse, search and play urls from soundcloud</desc>
-      <url>http://danielvijge.github.io/SqueezeCloud/{{ env['FOLDER'] }}/SqueezeCloud-{{ env['VERSION'] }}.zip</url>
+      <url>https://danielvijge.github.io/SqueezeCloud/{{ env['FOLDER'] }}/SqueezeCloud-{{ env['VERSION'] }}.zip</url>
       <link>https://github.com/danielvijge/SqueezeCloud</link>
       <sha>{{ env['SHA'] }}</sha>
       <creator>Robert Siebert, Daniel Vijge, Robert Gibbon, David Blackman</creator>


### PR DESCRIPTION
- Download installation zip with HTTPS.
- Use HTTPS in links.

Working SSL is required for the plugin, and many of these links already redirect to HTTPS anyway.