### PR TITLE
provider shall return empty hash when nothing is found

### DIFF
--- a/Plugin.pm
+++ b/Plugin.pm
@@ -353,7 +353,7 @@ sub metadata_provider {
 		fetchMetadata( $client, $url );
 	}
 	
-	return defaultMeta( $client, $url );
+	return { };
 }
 
 sub urlHandler {


### PR DESCRIPTION
The metadata_provider function returns a hash with almost nothing when it does not have anything in cache. I think it should return an empty hash (because it's a provider). Otherwise, other services that use soundcloud to retrieve content (e.g.) podcast will see their getMetadataFor result preempted by the soundcloud plugin's  metadata_provider. I think likely the registerProvider should be narrower in term of what it captures as well, but I'll let you decide