### PR TITLE
Fix seeking: move -ss after -i for SoundCloud HLS streams

### DIFF
--- a/ProtocolHandler.pm
+++ b/ProtocolHandler.pm
@@ -54,6 +54,7 @@ my $prefs = preferences('plugin.squeezecloud');
 my $prefix = 'sc:';
 
 sub canSeek { 1 }
+
 sub canTranscodeSeek { 1 }
 
 sub getSeekData {
@@ -145,6 +146,14 @@ sub getBetterArtworkURL {
 
 sub getFormatForURL { 'soundcloud' } # custom-convert type
 
+# When seeking, fetch the URL again. SoundCloud streams have an expiry time. Seeking
+# forward should not cause an issue, as the end of the song will always be before
+# the expiry time. But seeking backwards and then playing until the end could result
+# in the end of the song being after the expiry time. By refreshing the URL when
+# seeking this problem is avoided. Using `formatOverride()` might not be the
+# proper solution for this, but it appears this custom function from a plugin
+# happens to be called at the right time.
+# Ref: https://github.com/LMS-Community/slimserver/blob/91c0d2f13929b57fc5d06a2cd7b4ea40be597547/Slim/Player/Song.pm#L377
 sub formatOverride {
 	my ($class, $song) = @_;
 

--- a/ProtocolHandler.pm
+++ b/ProtocolHandler.pm
@@ -53,7 +53,13 @@ my $prefs = preferences('plugin.squeezecloud');
 
 my $prefix = 'sc:';
 
-sub canSeek { 0 }
+sub canSeek { 1 }
+sub canTranscodeSeek { 1 }
+
+sub getSeekData {
+	my ($class, $client, $song, $newtime) = @_;
+	return { timeOffset => $newtime };
+}
 
 sub _makeMetadata {
 	my ($json) = shift;
@@ -138,6 +144,18 @@ sub getBetterArtworkURL {
 }
 
 sub getFormatForURL { 'soundcloud' } # custom-convert type
+
+sub formatOverride {
+	my ($class, $song) = @_;
+
+	my $track = $song->pluginData();
+	if ($track && $track->{'uri'}) {
+		my $stream = getStreamURL($track);
+		$song->streamUrl($stream) if $stream;
+	}
+
+	return 'soundcloud';
+}
 
 sub isRemote { 1 }
 

--- a/custom-convert.conf
+++ b/custom-convert.conf
@@ -1,12 +1,12 @@
 # SoundCloud convert hls m3u8
 soundcloud mp3 * *
         # RB:{BITRATE=-B %B}T:{START=-ss %s}
-        [ffmpeg] -loglevel quiet  -i $URL$ -f wav - | [lame] --silent -q $QUALITY$ $BITRATE$ - -
+        [ffmpeg] -loglevel quiet -i $URL$ $START$ -f wav - | [lame] --silent -q $QUALITY$ $BITRATE$ - -
 
 soundcloud pcm * *
         # RB:{BITRATE=-B %B}T:{START=-ss %s}
-        [ffmpeg] -loglevel quiet  -i $URL$ -f u16le -
+        [ffmpeg] -loglevel quiet -i $URL$ $START$ -f u16le -
 
 soundcloud flc * *
         # RB:{BITRATE=-B %B}T:{START=-ss %s}
-        [ffmpeg] -loglevel quiet -i $URL$ -f flac -
+        [ffmpeg] -loglevel quiet -i $URL$ $START$ -f flac -


### PR DESCRIPTION
SoundCloud HLS playlists do not support ffmpeg input-seeking (-ss before -i), which silently produces no output. Move -ss after -i (output-seeking) so ffmpeg decodes from start and discards up to the seek point.

Also add formatOverride to refresh expired stream URLs on seek, and canSeek/canTranscodeSeek/getSeekData for transcoder-based seeking.

Purely vibe coded, I had no idea what I'm doing :)