### PR TITLE
Use PCM signed 16-bit little-endian for audio conversion

### DIFF
--- a/custom-convert.conf
+++ b/custom-convert.conf
@@ -5,7 +5,7 @@ soundcloud mp3 * *
 
 soundcloud pcm * *
         # RB:{BITRATE=-B %B}T:{START=-ss %s}
-        [ffmpeg] -loglevel quiet  -i $URL$ -f u16le -
+        [ffmpeg] -loglevel quiet  -i $URL$ -f s16le -
 
 soundcloud flc * *
         # RB:{BITRATE=-B %B}T:{START=-ss %s}


### PR DESCRIPTION
Some tracks from SoundCloud are garbled when converted to unsigned 16-bit little-endian.

Fixes: #58